### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "illuminate/support": "^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 9 doesnt require 8.1, this is breaking for packages still requiring 8.0.

Lots of hosting providers dont support 8.1 yet, theyre only on 8.0