### PR TITLE
chore/stub_presenter

### DIFF
--- a/src/Console/stubs/custom-presenter.php.stub
+++ b/src/Console/stubs/custom-presenter.php.stub
@@ -7,9 +7,7 @@ use TheHiveTeam\Presentable\Presenter;
 class DummyClass extends Presenter
 {
     /**
-     * This is a example.
-     *
-     * @return string
+     * This is an example.
      */
     public function name(): string
     {


### PR DESCRIPTION
Use an instead of 'a' if the following word starts with a vowel sound