### PR TITLE
feature/update-laravel-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
     test:
       runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          php-version: ['8.3', '8.4', '8.5']
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -12,7 +15,7 @@ jobs:
         - name: Setup PHP
           uses: shivammathur/setup-php@master
           with:
-            php-version: 8.2
+            php-version: ${{ matrix.php-version }}
 
         - name: Install dependencies
           run: composer install -n --prefer-dist --no-interaction --no-suggest --no-progress --optimize-autoloader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-presentable` will be documented in this file
 
+## 1.5.0 - 2026-03-24
+
+- Add support for Laravel 13
+- Update minimum PHP version requirement to 8.3
+- Add PHPUnit 12 support
+- Add Orchestra Testbench 11 support
+- Update CI matrix to test against PHP 8.3, 8.4, and 8.5
+
 ## 1.4.0 - 2025-08-25
 
 - Add support for Laravel 12

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can install the package via composer:
 | 10      | 1.2.0   |
 | 11      | 1.3.0   |
 | 12      | 1.4.0   |
+| 13      | 1.5.0   |
 
 ```bash
 composer require datacreativa/laravel-presentable

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "~6.0|~7.0|~8.0|~9.0|^10.0|^11.0|^12.0"
+        "php": "^8.3",
+        "illuminate/support": "~6.0|~7.0|~8.0|~9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage/>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>


### PR DESCRIPTION
This pull request introduces support for Laravel 13 and updates the package to require PHP 8.3 or higher. It also adds compatibility with PHPUnit 12 and Orchestra Testbench 11, and expands the CI matrix to test against PHP 8.3, 8.4, and 8.5. Documentation and configuration files have been updated to reflect these changes.

**Framework and Dependency Support:**
* Added support for Laravel 13 by updating the `illuminate/support` dependency in `composer.json`.
* Increased minimum PHP requirement to 8.3 in `composer.json` and expanded the test matrix in the CI workflow to include PHP 8.3, 8.4, and 8.5. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R24) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R8-R18)
* Added support for PHPUnit 12 and Orchestra Testbench 11 in `composer.json`.

**Continuous Integration and Testing:**
* Updated the GitHub Actions workflow (`main.yml`) to test against PHP 8.3, 8.4, and 8.5.
* Updated `phpunit.xml` to use the PHPUnit 12 schema.

**Documentation:**
* Updated `CHANGELOG.md` and `README.md` to reflect the new version (1.5.0), Laravel 13 support, and the updated PHP requirement. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21)